### PR TITLE
Align workspace root crate with Rust 2024 edition

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "img-scraper"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 [workspace]
 resolver = "3"


### PR DESCRIPTION
### Motivation
- Ensure the workspace uses a consistent Rust edition by updating the root crate from `2021` to `2024` to match member crates and avoid tooling or language-semantic mismatches.

### Description
- Updated the `edition` field in the workspace root `Cargo.toml` from `2021` to `2024`.

### Testing
- Ran `cargo check --workspace` and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_687dc190cf2c832c975b2c574518609f)