### PR TITLE
Add README for workspace overview and usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,55 @@
+# img-scraper
+
+A small Rust workspace for experimenting with crate boundaries and tracing-based observability.
+
+## Workspace layout
+
+- `img-scraper` (root package): default binary scaffold currently printing `Hello, world!`.
+- `api`: example application entrypoint that configures logging and calls into the domain layer.
+- `domain`: business logic (`add`) instrumented with `tracing`.
+- `logging`: shared logging bootstrap using `tracing-subscriber`.
+
+## Prerequisites
+
+- Rust toolchain (stable)
+- Cargo
+
+## Build
+
+```bash
+cargo build
+```
+
+## Run
+
+Run the API binary from the workspace root:
+
+```bash
+cargo run -p api
+```
+
+Expected output includes a tracing span/event and:
+
+```text
+The answer is: 109
+```
+
+You can also run the root scaffold binary:
+
+```bash
+cargo run -p img-scraper
+```
+
+## Test
+
+Run all workspace tests:
+
+```bash
+cargo test
+```
+
+## Notes
+
+- The `api` crate demonstrates composition of `domain` and `logging`.
+- `domain::add` is instrumented with `#[tracing::instrument]` and emits an info-level event.
+- `logging::setup_logging` enables formatted tracing output and active span lifecycle events.


### PR DESCRIPTION
### Motivation
- Provide a top-level `README.md` that documents the workspace layout, how to build/run/test the project, and the tracing/logging integration used across crates.

### Description
- Add a root `README.md` that describes the crates (`img-scraper`, `api`, `domain`, `logging`), lists prerequisites, and documents `cargo build`, `cargo run -p api`, `cargo run -p img-scraper`, and `cargo test` usage, plus notes about `domain::add` instrumentation and `logging::setup_logging`.

### Testing
- Ran `cargo test` and `cargo test --workspace`, and all workspace tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a3c009480832cbf00adcb04fdfa05)