### PR TITLE
Add manual 'Seed Issues' workflow with dry-run and duplicate-title skipping

### DIFF
--- a/.github/workflows/seed_issues.yml
+++ b/.github/workflows/seed_issues.yml
@@ -1,0 +1,66 @@
+name: Seed Issues
+
+on:
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Set to "false" to actually create issues'
+        required: true
+        default: "true"
+
+permissions:
+  issues: write
+  contents: read
+
+jobs:
+  seed:
+    runs-on: ubuntu-latest
+    env:
+      REPO: ${{ github.repository }}
+      DRY_RUN: ${{ github.event.inputs.dry_run }}
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Install jq
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y jq
+
+      - name: Seed issues from backlog/issues.json
+        run: |
+          set -euo pipefail
+
+          issues_file="backlog/issues.json"
+
+          if [[ ! -f "$issues_file" ]]; then
+            echo "Missing $issues_file"
+            exit 1
+          fi
+
+          # Gather current issue titles (all states), excluding pull requests.
+          existing_titles_file="$(mktemp)"
+          gh api "/repos/${REPO}/issues?state=all&per_page=100" \
+            --jq '.[] | select(.pull_request | not) | .title' \
+            > "$existing_titles_file"
+
+          # Process each seeded issue. Skip existing titles for idempotency.
+          jq -c '.[]' "$issues_file" | while IFS= read -r issue; do
+            title="$(jq -r '.title' <<< "$issue")"
+            body="$(jq -r '.body' <<< "$issue")"
+
+            if grep -Fxq "$title" "$existing_titles_file"; then
+              echo "SKIP (exists): $title"
+              continue
+            fi
+
+            if [[ "$DRY_RUN" == "true" ]]; then
+              echo "WOULD CREATE: $title"
+            else
+              gh api "/repos/${REPO}/issues" \
+                -f title="$title" \
+                -f body="$body" >/dev/null
+              echo "CREATED: $title"
+            fi
+          done

--- a/README.md
+++ b/README.md
@@ -53,3 +53,13 @@ cargo test
 - The `api` crate demonstrates composition of `domain` and `logging`.
 - `domain::add` is instrumented with `#[tracing::instrument]` and emits an info-level event.
 - `logging::setup_logging` enables formatted tracing output and active span lifecycle events.
+
+## Seeding issues
+
+Use the manual GitHub Actions workflow to seed issues from `backlog/issues.json`:
+
+1. Go to **Actions** → **Seed Issues** → **Run workflow**.
+2. Run once with `dry_run=true` (default) to preview what would be created.
+3. Run again with `dry_run=false` to create only missing issues.
+
+The workflow skips any issue whose title already exists (open or closed), so it is safe to re-run.

--- a/backlog/issues.json
+++ b/backlog/issues.json
@@ -1,0 +1,10 @@
+[
+  {
+    "title": "Add CI (fmt, clippy, test)",
+    "body": "## Summary\nSet up a CI workflow for this Rust workspace that checks formatting, linting, and tests on pull requests.\n\n## Acceptance criteria\n- A GitHub Actions workflow runs on pull requests and pushes to `mainline`.\n- `cargo fmt --all -- --check` passes in CI.\n- `cargo clippy --workspace --all-targets -- -D warnings` passes in CI.\n- `cargo test --workspace` passes in CI.\n- Workflow output is clear enough to identify which step failed."
+  },
+  {
+    "title": "Make logging initialization idempotent",
+    "body": "## Summary\nEnsure logging setup can be called multiple times safely without panics or duplicate subscriber registration errors.\n\n## Acceptance criteria\n- Calling `logging::setup_logging()` more than once does not panic.\n- Repeated initialization does not register duplicate global subscribers.\n- Behavior is covered by at least one automated test.\n- README or crate docs explain the idempotent behavior briefly."
+  }
+]


### PR DESCRIPTION
### Motivation

- Provide a safe, manual way to bulk-create issues from a repo-local backlog file to bootstrap project tracking. 
- Ensure idempotent behavior so re-running the operation does not create duplicates by skipping any exact-title matches (open or closed). 
- Keep the workflow minimal and secure by using the built-in `GITHUB_TOKEN` (`secrets.GITHUB_TOKEN`) and the least required permissions. 

### Description

- Add `backlog/issues.json` with two starter issues titled `Add CI (fmt, clippy, test)` and `Make logging initialization idempotent`, each including clear summaries and acceptance criteria. 
- Add `.github/workflows/seed_issues.yml`, a manual-only workflow (`workflow_dispatch`) with a `dry_run` input (string `

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a43e53d28832c85232cf91b0947f0)